### PR TITLE
Slime Hotfix

### DIFF
--- a/Modules/Enemies/EnemyAI/Scripts/slime.gd
+++ b/Modules/Enemies/EnemyAI/Scripts/slime.gd
@@ -10,6 +10,7 @@ var wander_timer = 0.0; # internal timer for wander
 @export var gravity_strength = 10
 var is_jumping = false
 var in_combat = false
+var rotation_factor = 1.02  # scales how quickly slime rotate back to 0 degrees (upright)
 
 # for animations
 @onready var animation_player: AnimationPlayer = $AnimationPlayer
@@ -30,6 +31,16 @@ func _process(delta):
 		seek()
 	else:
 		wander()
+		
+	# prevent slime from rotating upside down
+	if global_rotation_degrees != 0:
+		print("SLIME ROTATION: " + str(get_instance_id()) + " " + str(global_rotation_degrees))
+		global_rotation_degrees /= rotation_factor
+	
+	# set rotation to zero once it approaches zero
+	if global_rotation_degrees <= 0.0125:
+		global_rotation_degrees = 0 
+	
 	move_and_collide(velocity)
 	
 	# TODO: animation player is null for some reason...

--- a/Modules/Enemies/EnemyAI/Scripts/slime.gd
+++ b/Modules/Enemies/EnemyAI/Scripts/slime.gd
@@ -8,9 +8,9 @@ var wander_timer = 0.0; # internal timer for wander
 @export var min_wander_interval = 1 # min time in seconds that the slime will wander in one direction
 @export var max_wander_interval = 2 # max time in seconds that the slime will wander in one direction
 @export var gravity_strength = 10
+@export var rotation_factor = 1.02  # scales how quickly slime rotate back to 0 degrees (upright)
 var is_jumping = false
 var in_combat = false
-var rotation_factor = 1.02  # scales how quickly slime rotate back to 0 degrees (upright)
 
 # for animations
 @onready var animation_player: AnimationPlayer = $AnimationPlayer
@@ -37,8 +37,8 @@ func _process(delta):
 		print("SLIME ROTATION: " + str(get_instance_id()) + " " + str(global_rotation_degrees))
 		global_rotation_degrees /= rotation_factor
 	
-	# set rotation to zero once it approaches zero
-	if global_rotation_degrees <= 0.0125:
+	# set rotation to zero once it approaches zero 
+	if ((global_rotation_degrees <= 0.125) and (global_rotation_degrees >= -0.125)):
 		global_rotation_degrees = 0 
 	
 	move_and_collide(velocity)

--- a/project.godot
+++ b/project.godot
@@ -109,6 +109,10 @@ right_mouse={
 ]
 }
 
+[physics]
+
+common/max_physics_steps_per_frame=32
+
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0


### PR DESCRIPTION
1. Prevents slime from getting stuck upside down by adding a righting factor. They now slowly return to their default orientation if they flip upside down.
2. Prevents slime from phasing into the ground / terrain by increasing physics steps per frame.